### PR TITLE
add recipes link to the sidebar

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,11 +2,7 @@ version: 1.0
 shards:
   amber:
     github: amberframework/amber
-    version: 0.6.1
-
-  amber_spec:
-    github: amberframework/amber-spec
-    version: 0.1.2
+    version: 0.6.7
 
   callback:
     github: mosop/callback
@@ -19,6 +15,10 @@ shards:
   db:
     github: crystal-lang/crystal-db
     version: 0.5.0
+
+  garnet_spec:
+    github: amberframework/garnet-spec
+    version: 0.1.1
 
   kilt:
     github: jeromegn/kilt
@@ -52,17 +52,13 @@ shards:
     github: ysbaddaden/selenium-webdriver-crystal
     version: 0.3.0
 
-  sentry:
-    github: samueleaton/sentry
-    version: 0.1.1
-
   shell-table:
     github: jwaldrip/shell-table.cr
     version: 0.9.2
 
   slang:
     github: jeromegn/slang
-    commit: 33d5c2c2075460094784904e7ecdd3cd21c8d36e
+    version: 1.7.1
 
   spinner:
     github: askn/spinner

--- a/shard.yml
+++ b/shard.yml
@@ -11,8 +11,8 @@ license: MIT
 dependencies:
   amber:
     github: amberframework/amber
-    version: 0.6.1
+    version: 0.6.7
 
 development_dependencies:
-  amber_spec:
-    github: amberframework/amber-spec
+  garnet_spec:
+    github: amberframework/garnet-spec

--- a/src/views/layouts/_sidebar.slang
+++ b/src/views/layouts/_sidebar.slang
@@ -87,9 +87,10 @@
       a.list-group-item data-parent="#menu7" href="/getting-started/cli/encrypt.md#cli-encrypt" id="cli-encrypt" Encrypt
       a.list-group-item data-parent="#menu7" href="/getting-started/cli/routes.md#cli-routes" id="cli-routes" Routes
       a.list-group-item data-parent="#menu7" href="/getting-started/cli/watch.md#cli-watch" id="cli-watch" Watch
+      a.list-group-item data-parent="#menu7" href="/getting-started/cli/recipes.md#cli-recipes" id="cli-recipes" Recipes
 
       br
-      strong RECIPES
+      strong COOKBOOK
 
       a.list-group-item href="/recipes/examples/amber-auth-example.md#amber-auth-example" id="amber-auth-example" Amber Auth Example
       a.list-group-item href="/recipes/debugging/vs-code-debug.md#vs-code-debug" id="vs-code-debug" VS Code Debugging


### PR DESCRIPTION
added a link to the sidebar to a page describing recipes and changed the name of the existing RECIPES section to COOKBOOK to avoid any confusion.