### PR TITLE
Remove Unused Google Analytics

### DIFF
--- a/src/assets/javascripts/thesaas.js
+++ b/src/assets/javascripts/thesaas.js
@@ -14,7 +14,6 @@
 
   thesaas.defaults = {
     googleApiKey: null,
-    googleAnalyticsId: null,
     smoothScroll: false,
   }
 
@@ -55,21 +54,6 @@
     // 
     if ($('[data-provide~="map"]').length && window["google.maps.Map"] === undefined) {
       $.getScript("https://maps.googleapis.com/maps/api/js?key=" + thesaas.defaults.googleApiKey + "&callback=thesaas.map");
-    }
-
-
-    // Google Analytics
-    //
-    if (thesaas.defaults.googleAnalyticsId) {
-      (function (i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-          (i[r].q = i[r].q || []).push(arguments)
-        }, i[r].l = 1 * new Date(); a = s.createElement(o),
-          m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-
-      ga('create', thesaas.defaults.googleAnalyticsId, 'auto');
-      ga('send', 'pageview');
     }
 
   }


### PR DESCRIPTION
Hi Amber Team, today I was just reviewing my GA profile and I see the previous GA account for Amber Framework website has not been in use for years, is the team still using GA or is deprecated already?

Maybe other alternatives are better like https://plausible.io/